### PR TITLE
net-misc/frr: Fix useflag typo of net-misc/frr-9999

### DIFF
--- a/net-misc/frr/frr-9999.ebuild
+++ b/net-misc/frr/frr-9999.ebuild
@@ -132,7 +132,7 @@ src_install() {
 	use systemd && systemd_dounit "${FILESDIR}/systemd/zebra.service"
 
 	# install zebra as a file, symlink the rest
-	use sysemd || newinitd "${FILESDIR}"/frr.init zebra
+	use systemd || newinitd "${FILESDIR}"/frr.init zebra
 
 	for service in zebra staticd \
 			$(usex bgp bgpd) \


### PR DESCRIPTION
Package-Manager: Portage-2.3.51, Repoman-2.3.11