### PR TITLE
net-misc/frr: Correcting zebra symlink. Fixes #53

### DIFF
--- a/net-misc/frr/files/frr.init
+++ b/net-misc/frr/files/frr.init
@@ -1,5 +1,5 @@
 #!/sbin/openrc-run
-# Copyright 1999-2013 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 : ${CFGFILE:=/etc/frr/${SVCNAME}.conf}
@@ -7,7 +7,8 @@
 pidfile=/run/frr/${SVCNAME}.pid
 
 command=/usr/sbin/${SVCNAME}
-command_args="-d -f ${CFGFILE} ${EXTRA_OPTS} --pid_file ${pidfile}"
+command_args="-f ${CFGFILE} ${EXTRA_OPTS}"
+command_background="true"
 
 get_service_config() {
 	[ -e "$CFGFILE" ] || return

--- a/net-misc/frr/files/frr.init
+++ b/net-misc/frr/files/frr.init
@@ -4,7 +4,7 @@
 
 : ${CFGFILE:=/etc/frr/${SVCNAME}.conf}
 
-pidfile=/run/frr/${SVCNAME}.pid
+pidfile=/run/frr-${SVCNAME}.pid
 
 command=/usr/sbin/${SVCNAME}
 command_args="-f ${CFGFILE} ${EXTRA_OPTS}"

--- a/net-misc/frr/frr-7.0-r1.ebuild
+++ b/net-misc/frr/frr-7.0-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -134,7 +134,9 @@ src_install() {
 	# install zebra as a file, symlink the rest
 	use systemd || newinitd "${FILESDIR}"/frr.init zebra
 
-	for service in zebra staticd \
+	newinitd "${FILESDIR}/${PN}.init" zebra
+
+	for service in staticd \
 			$(usex bgp bgpd "") \
 			$(usex rip ripd "") \
 			$(usex ospf ospfd "") \

--- a/net-misc/frr/frr-7.1-r1.ebuild
+++ b/net-misc/frr/frr-7.1-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -135,7 +135,9 @@ src_install() {
 	# install zebra as a file, symlink the rest
 	use systemd || newinitd "${FILESDIR}"/frr.init zebra
 
-	for service in zebra staticd \
+	newinitd "${FILESDIR}/${PN}.init" zebra
+
+	for service in staticd \
 			$(usex bgp bgpd "") \
 			$(usex rip ripd "") \
 			$(usex ospf ospfd "") \

--- a/net-misc/frr/frr-7.1.ebuild
+++ b/net-misc/frr/frr-7.1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2019 Gentoo Authors
+# Copyright 2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -134,7 +134,9 @@ src_install() {
 	# install zebra as a file, symlink the rest
 	use systemd || newinitd "${FILESDIR}"/frr.init zebra
 
-	for service in zebra staticd \
+	newinitd "${FILESDIR}/${PN}.init" zebra
+
+	for service in staticd \
 			$(usex bgp bgpd "") \
 			$(usex rip ripd "") \
 			$(usex ospf ospfd "") \


### PR DESCRIPTION
Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Alarig Le Lay <alarig@swordarmor.fr>

```
rr2 ~ # ls -lh /var/tmp/portage/net-misc/frr-7.1/image/etc/init.d/                        
total 4.0K                                                                                
lrwxrwxrwx 1 root root    5 Mar 21 23:02 babeld -> zebra                                  
lrwxrwxrwx 1 root root    5 Mar 21 23:02 bgpd -> zebra                                    
lrwxrwxrwx 1 root root    5 Mar 21 23:02 eigrpd -> zebra                                  
lrwxrwxrwx 1 root root    5 Mar 21 23:02 fabricd -> zebra                                 
lrwxrwxrwx 1 root root    5 Mar 21 23:02 isisd -> zebra                                   
lrwxrwxrwx 1 root root    5 Mar 21 23:02 ldpd -> zebra                                    
lrwxrwxrwx 1 root root    5 Mar 21 23:02 nhrpd -> zebra                                   
lrwxrwxrwx 1 root root    5 Mar 21 23:02 ospf6d -> zebra                                  
lrwxrwxrwx 1 root root    5 Mar 21 23:02 ospfd -> zebra                                   
lrwxrwxrwx 1 root root    5 Mar 21 23:02 pbrd -> zebra                                    
lrwxrwxrwx 1 root root    5 Mar 21 23:02 pimd -> zebra                                    
lrwxrwxrwx 1 root root    5 Mar 21 23:02 ripd -> zebra
lrwxrwxrwx 1 root root    5 Mar 21 23:02 ripngd -> zebra
lrwxrwxrwx 1 root root    5 Mar 21 23:02 staticd -> zebra
-rwxr-xr-x 1 root root 1.1K Mar 21 23:02 zebra
