### PR TITLE
net-misc/frr: use recommended libyang version

### DIFF
--- a/net-misc/frr/frr-7.0-r1.ebuild
+++ b/net-misc/frr/frr-7.0-r1.ebuild
@@ -39,7 +39,7 @@ COMMON_DEPEND="
 	snmp? ( net-analyzer/net-snmp )
 	!elibc_glibc? ( dev-libs/libpcre )
 	rpki? ( >=net-libs/rtrlib-0.6.3[ssh] )
-	>=net-libs/libyang-0.16-r3"
+	=net-libs/libyang-0.16*"
 DEPEND="${COMMON_DEPEND}
 	dev-perl/XML-LibXML
 	sys-apps/gawk

--- a/net-misc/frr/frr-7.0.ebuild
+++ b/net-misc/frr/frr-7.0.ebuild
@@ -39,7 +39,7 @@ COMMON_DEPEND="
 	snmp? ( net-analyzer/net-snmp )
 	!elibc_glibc? ( dev-libs/libpcre )
 	rpki? ( >=net-libs/rtrlib-0.6.3[ssh] )
-	>=net-libs/libyang-0.16-r3"
+	=net-libs/libyang-0.16*"
 DEPEND="${COMMON_DEPEND}
 	dev-perl/XML-LibXML
 	sys-apps/gawk

--- a/net-misc/frr/frr-7.1-r1.ebuild
+++ b/net-misc/frr/frr-7.1-r1.ebuild
@@ -40,7 +40,7 @@ COMMON_DEPEND="
 	!elibc_glibc? ( dev-libs/libpcre )
 	rpki? ( >=net-libs/rtrlib-0.6.3[ssh] )
 	sanitize? ( sys-devel/gcc:*[sanitize] )
-	>=net-libs/libyang-0.16-r3"
+	=net-libs/libyang-0.16*"
 DEPEND="${COMMON_DEPEND}
 	dev-perl/XML-LibXML
 	sys-apps/gawk

--- a/net-misc/frr/frr-7.1.ebuild
+++ b/net-misc/frr/frr-7.1.ebuild
@@ -39,7 +39,7 @@ COMMON_DEPEND="
 	snmp? ( net-analyzer/net-snmp )
 	!elibc_glibc? ( dev-libs/libpcre )
 	rpki? ( >=net-libs/rtrlib-0.6.3[ssh] )
-	>=net-libs/libyang-0.16-r3"
+	=net-libs/libyang-0.16*"
 DEPEND="${COMMON_DEPEND}
 	dev-perl/XML-LibXML
 	sys-apps/gawk

--- a/net-misc/frr/frr-9999.ebuild
+++ b/net-misc/frr/frr-9999.ebuild
@@ -40,7 +40,7 @@ COMMON_DEPEND="
 	!elibc_glibc? ( dev-libs/libpcre )
 	rpki? ( >=net-libs/rtrlib-0.6.3[ssh] )
 	sanitize? ( sys-devel/gcc:*[sanitize] )
-	>=net-libs/libyang-0.16-r3"
+	>=net-libs/libyang-1.0"
 DEPEND="${COMMON_DEPEND}
 	dev-perl/XML-LibXML
 	sys-apps/gawk


### PR DESCRIPTION
## Summary

Please read issue #55 for more information.

`libyang` 1.0 and greater are known to cause problem with most FRR versions and `master` is just moving to version 1.0 (see the PR the issue above talks about). Lets avoid our users to hit strange issues by using the good known versions mix.