### PR TITLE
net-misc/frr: add missing metadata information

### DIFF
--- a/net-misc/frr/metadata.xml
+++ b/net-misc/frr/metadata.xml
@@ -16,6 +16,9 @@
 		<flag name="bgp">
 			Enable bgpd
 		</flag>
+		<flag name="grpc">
+			Enable gRPC plugin
+		</flag>
 		<flag name="rip">
 			Enable ripd
 		</flag>


### PR DESCRIPTION
Summary
------------

Add missing FRR metadata information.

Currently it looks like this:

```sh
% equery u frr
[ Legend : U - final flag setting for installation]
[        : I - package is installed with flag     ]
[ Colors : set, unset                             ]
 * Found these USE flags for net-misc/frr-7.4:
 U I
...
 + + grpc     : <unknown>
```

Then we get:

```
 % equery u frr
[ Legend : U - final flag setting for installation]
[        : I - package is installed with flag     ]
[ Colors : set, unset                             ]
 * Found these USE flags for net-misc/frr-7.4:
 U I
...
 + + grpc     : Enable gRPC plugin
```